### PR TITLE
Fix startup race condition

### DIFF
--- a/kafka-live-project/create-topics.sh
+++ b/kafka-live-project/create-topics.sh
@@ -1,8 +1,9 @@
+#!/bin/bash
+set -e
 
-
-/bin/kafka-topics --create --topic test-topic --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
-/bin/kafka-topics --create --topic ORDER_RECEIVED --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
-/bin/kafka-topics --create --topic ORDER_CONFIRMED --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
-/bin/kafka-topics --create --topic ORDER_PICKED_UP --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
-/bin/kafka-topics --create --topic ORDER_SENT_OUT --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
-/bin/kafka-topics --create --topic MESSAGE_CONSUME_FAILED --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+kafka-topics --create --topic test-topic --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+kafka-topics --create --topic ORDER_RECEIVED --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+kafka-topics --create --topic ORDER_CONFIRMED --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+kafka-topics --create --topic ORDER_PICKED_UP --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+kafka-topics --create --topic ORDER_SENT_OUT --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+kafka-topics --create --topic MESSAGE_CONSUME_FAILED --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1

--- a/kafka-live-project/startup.sh
+++ b/kafka-live-project/startup.sh
@@ -1,6 +1,14 @@
+#!/bin/bash
+set -e
+
 docker compose up -d
+
+echo "Waiting for Kafka broker to become healthy..."
+until [ "$(docker inspect -f '{{.State.Health.Status}}' kafka 2>/dev/null)" = "healthy" ]; do
+    sleep 1
+done
 
 docker exec kafka sh /usr/local/bin/create-topics.sh
 
-
-# docker exec kafka /bin/kafka-console-consumer --topic test-topic --bootstrap-server localhost:9092 --from-beginning
+# Example consumer command
+# docker exec kafka kafka-console-consumer --topic test-topic --bootstrap-server localhost:9092 --from-beginning


### PR DESCRIPTION
## Summary
- ensure Kafka container is ready before creating topics
- add shebangs and strict error handling to scripts

## Testing
- `bash -n kafka-live-project/startup.sh`
- `bash -n kafka-live-project/create-topics.sh`


------
https://chatgpt.com/codex/tasks/task_e_684d093f37508322abe500e311278232